### PR TITLE
security: SHA-pin GitHub Actions in smart-test.yml

### DIFF
--- a/.github/workflows/smart-test.yml
+++ b/.github/workflows/smart-test.yml
@@ -22,7 +22,7 @@ jobs:
       test-category: ${{ steps.analyze-commit.outputs.test-category }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -97,11 +97,11 @@ jobs:
     if: needs.detect-changes.outputs.js-changed == 'true' || needs.detect-changes.outputs.python-changed == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
         if: needs.detect-changes.outputs.js-changed == 'true'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -116,7 +116,7 @@ jobs:
 
       - name: Setup Python
         if: needs.detect-changes.outputs.python-changed == 'true'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.x'
           cache: 'pip'
@@ -136,10 +136,10 @@ jobs:
     if: needs.detect-changes.outputs.commit-type == 'dependency'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -151,7 +151,7 @@ jobs:
         run: npm run build
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
 
       - name: Verify Python dependencies
         run: |
@@ -168,10 +168,10 @@ jobs:
         shard: [1, 2, 3]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -191,10 +191,10 @@ jobs:
     if: needs.detect-changes.outputs.python-changed == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.x'
           cache: 'pip'
@@ -217,10 +217,10 @@ jobs:
       needs.detect-changes.outputs.test-category == 'full'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -234,7 +234,7 @@ jobs:
         run: npx vitest run --config=vitest.config.js tests/integration
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.x'
           cache: 'pip'
@@ -253,10 +253,10 @@ jobs:
     if: needs.detect-changes.outputs.commit-type == 'daily'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -273,7 +273,7 @@ jobs:
         run: npx vitest run --config=vitest.config.js tests/unit/utils/DailyBirdUtils.test.jsx
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
 
       - name: Run Python daily generation tests
         run: |
@@ -290,10 +290,10 @@ jobs:
       needs.detect-changes.outputs.test-category == 'standard'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '24'
           cache: 'npm'


### PR DESCRIPTION
## Summary
PIN all GitHub Actions to immutable commit SHAs for supply chain security.

## Changes
- `actions/checkout@v6` → `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (7 occurrences)
- `actions/setup-node@v6` → `53b83947a5a98c8d113130e565377fae1a50d02f` (6 occurrences)  
- `actions/setup-python@v6` → `a309ff8b426b58ec0e2a45f0f869d46889d02405` (6 occurrences)

## Security Rationale
Version tags are mutable - a compromised action repository could retag `v6` to point to malicious code. SHA-pinning ensures the exact code is immutable and verifiable.

Already SHA-pinned: `dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1`

## Test Plan
- [ ] CI passes (same actions, just pinned)
- [ ] SHA verification: `gh api repos/actions/checkout/git/ref/tags/v6 --jq .object.sha`