### PR TITLE
fix: eliminate PromiseRejectionHandledWarning in RetryUtils tests

### DIFF
--- a/tests/unit/utils/RetryUtils.test.jsx
+++ b/tests/unit/utils/RetryUtils.test.jsx
@@ -83,20 +83,15 @@ describe("RetryUtils", () => {
     });
 
     it("should throw error after max retries exhausted", async () => {
-      // Suppress unhandled rejection warnings for this test
-      const rejections = [];
-      const handler = (reason) => rejections.push(reason);
-      process.on("unhandledRejection", handler);
-
+      vi.useRealTimers();
       global.fetch = vi.fn(() => Promise.reject(new Error("Network error")));
 
-      const promise = fetchWithRetry("/data/test.json", {}, { maxRetries: 2 });
+      const promise = fetchWithRetry("/data/test.json", {}, { maxRetries: 2, baseDelay: 10 });
 
-      await vi.runAllTimersAsync();
       await expect(promise).rejects.toThrow("Network error");
-      expect(fetch).toHaveBeenCalledTimes(2); // 2 total attempts (maxRetries = 2)
+      expect(fetch).toHaveBeenCalledTimes(2);
 
-      process.off("unhandledRejection", handler);
+      vi.useFakeTimers();
     });
 
     it("should use custom config for retries and delay", async () => {
@@ -216,28 +211,22 @@ describe("RetryUtils", () => {
     });
 
     it("should log final error after all retries exhausted", async () => {
-      // Suppress unhandled rejection warnings for this test
-      const rejections = [];
-      const handler = (reason) => rejections.push(reason);
-      process.on("unhandledRejection", handler);
-
+      vi.useRealTimers();
       const consoleErrorSpy = vi.spyOn(console, "error");
+      const operation = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Permanent failure"))
+        .mockRejectedValueOnce(new Error("Permanent failure"));
 
-      const promise = retryWithBackoff(
-        async () => {
-          throw new Error("Permanent failure");
-        },
-        { maxRetries: 2 },
-      );
+      const promise = retryWithBackoff(operation, { maxRetries: 2, baseDelay: 10 });
 
-      await vi.runAllTimersAsync();
       await expect(promise).rejects.toThrow("Permanent failure");
 
       expect(consoleErrorSpy).toHaveBeenCalled();
       const errorCall = consoleErrorSpy.mock.calls[0];
       expect(errorCall[0]).toContain("operation failed after 2 attempts");
 
-      process.off("unhandledRejection", handler);
+      vi.useFakeTimers();
     });
   });
 });

--- a/tests/unit/utils/RetryUtils.test.jsx
+++ b/tests/unit/utils/RetryUtils.test.jsx
@@ -86,7 +86,11 @@ describe("RetryUtils", () => {
       vi.useRealTimers();
       global.fetch = vi.fn(() => Promise.reject(new Error("Network error")));
 
-      const promise = fetchWithRetry("/data/test.json", {}, { maxRetries: 2, baseDelay: 10 });
+      const promise = fetchWithRetry(
+        "/data/test.json",
+        {},
+        { maxRetries: 2, baseDelay: 10 },
+      );
 
       await expect(promise).rejects.toThrow("Network error");
       expect(fetch).toHaveBeenCalledTimes(2);
@@ -218,7 +222,10 @@ describe("RetryUtils", () => {
         .mockRejectedValueOnce(new Error("Permanent failure"))
         .mockRejectedValueOnce(new Error("Permanent failure"));
 
-      const promise = retryWithBackoff(operation, { maxRetries: 2, baseDelay: 10 });
+      const promise = retryWithBackoff(operation, {
+        maxRetries: 2,
+        baseDelay: 10,
+      });
 
       await expect(promise).rejects.toThrow("Permanent failure");
 

--- a/tests/unit/utils/RetryUtils.test.jsx
+++ b/tests/unit/utils/RetryUtils.test.jsx
@@ -229,6 +229,7 @@ describe("RetryUtils", () => {
 
       await expect(promise).rejects.toThrow("Permanent failure");
 
+      expect(operation).toHaveBeenCalledTimes(2);
       expect(consoleErrorSpy).toHaveBeenCalled();
       const errorCall = consoleErrorSpy.mock.calls[0];
       expect(errorCall[0]).toContain("operation failed after 2 attempts");


### PR DESCRIPTION
## Problem

Two tests in `RetryUtils.test.jsx` used fake timers with `vi.runAllTimersAsync()`, creating a timing gap between promise rejection and the test's `.rejects` handler. This caused Node to emit `PromiseRejectionHandledWarning` and Vitest to report 2 unhandled errors.

## Solution

Switch the two affected tests to **real timers** (`vi.useRealTimers()`) with a small `baseDelay: 10`ms so promise rejections are handled synchronously. Restore fake timers after each test to avoid polluting the rest of the suite.

Also replaced the always-throwing closure in the second test with `mockRejectedValueOnce` for more deterministic mock behavior.

## What changed

- `should throw error after max retries exhausted` — real timers, removed `process.on('unhandledRejection')` hack
- `should log final error after all retries exhausted` — real timers, removed `process.on('unhandledRejection')` hack, cleaner mock

## Verification

```
Test Files  26 passed (26)
     Tests  547 passed | 5 skipped (552)
    Errors  0 errors
```

Zero warnings, zero unhandled rejections. Source code (`RetryUtils.jsx`) is untouched.

---

Generated with help from [OpenCode](https://opencode.ai) using the **Big Pickle** model (free tier).