### PR TITLE
fix(ci): install script dependencies before pylint

### DIFF
--- a/.github/workflows/smart-test.yml
+++ b/.github/workflows/smart-test.yml
@@ -123,7 +123,9 @@ jobs:
 
       - name: Install Python dependencies
         if: needs.detect-changes.outputs.python-changed == 'true'
-        run: pip install pylint
+        run: |
+          pip install pylint
+          pip install -r scripts/requirements.txt
 
       - name: Run Pylint
         if: needs.detect-changes.outputs.python-changed == 'true'


### PR DESCRIPTION
Fixes the failing lint job that was blocking Renovate PRs #303, #304, #305.

**Problem:** The lint job runs pylint on Python scripts but only installs pylint itself, not the script dependencies. This causes import resolution failures for `dotenv`, `requests`, `pandas`, `selenium`, etc.

**Fix:** Install `scripts/requirements.txt` before running pylint.

Once merged, the blocked Renovate PRs should pass their CI checks.